### PR TITLE
fix: fix case sensitive check for random word and conversation

### DIFF
--- a/src/bot/conversation.py
+++ b/src/bot/conversation.py
@@ -60,7 +60,7 @@ def _get_llm_response(user_message, chat_history, bot, base_language_code):
     client: the OpenAI client object
     bot: the bot object to send the message
     """
-    if user_message.text == "end":
+    if user_message.text.lower() == "end":
         #Check if the user wanted to end the conversation with the "end", keyword.
         send_bot_response(bot, user_message, chat_history, base_language_code, "<b>Conversation ended</b>")
     else:

--- a/src/bot/random_word.py
+++ b/src/bot/random_word.py
@@ -55,10 +55,11 @@ def check_response(message, learning_language_word, bot, base_language_code, use
     learning_language_word: the correct translation of the word
     bot: the bot object to send the response
     """
-    if message.text == "end":
+    user_message = message.text.lower()
+    if user_message == "end":
         send_bot_response(bot, message, [], base_language_code, "Ending the game! 🛑")
         return
-    if message.text == learning_language_word:
+    if user_message == learning_language_word.lower():
         send_bot_response(bot, message, [], base_language_code, "Correct!", "✅")
         # ask_to_translate_a_word(bot, message, user_known_words, base_language_code)
     else:


### PR DESCRIPTION
Change case sensitive for random word and conversation.

I was asking "when a user sends 'end' command, end conversation, but from the phone the first word starts always with uppercase